### PR TITLE
Add console-based logging

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,25 +1,41 @@
-import { Player, RallyResult } from './types.js';
+import { Player, RallyResult, Logger } from './types.js';
 
-export function calculateResponse(player: Player, incoming: number, risk = 1): number {
+export function calculateResponse(
+  player: Player,
+  incoming: number,
+  risk = 1,
+  logger?: Logger
+): number {
   const product = player.technique * player.mind * player.physique * player.emotion;
   let quality = (product / 1000) * ((10 - incoming) / 10) * risk;
   if (quality > 10) quality = 10;
   if (quality < 0) quality = 0;
+  logger?.log('rallyDetailed', `${player.name} responds ${quality.toFixed(2)} to ${incoming}`);
   return quality;
 }
 
-export function simulateRally(server: Player, receiver: Player, firstShot = 5, risk = 1): RallyResult {
+export function simulateRally(
+  server: Player,
+  receiver: Player,
+  firstShot = 5,
+  risk = 1,
+  logger?: Logger
+): RallyResult {
   let hitter = receiver;
   let defender = server;
   let incoming = firstShot;
   const log = [incoming];
+  logger?.log('rally', `Rally starts. Server ${server.name} first ${firstShot}`);
   while (true) {
-    const response = calculateResponse(hitter, incoming, risk);
+    const response = calculateResponse(hitter, incoming, risk, logger);
     log.push(response);
+    logger?.log('rallyDetailed', `${hitter.name} -> ${response.toFixed(2)}`);
     if (response >= 9) {
+      logger?.log('rally', `Rally winner ${hitter.name}`);
       return { winner: hitter, log };
     }
     if (response <= 2) {
+      logger?.log('rally', `Rally winner ${defender.name}`);
       return { winner: defender, log };
     }
     incoming = response;

--- a/src/game.ts
+++ b/src/game.ts
@@ -1,21 +1,30 @@
-import { Player, GameResult } from './types.js';
+import { Player, GameResult, Logger } from './types.js';
 import { simulateRally } from './engine.js';
 
-export function simulateGame(playerA: Player, playerB: Player, server: Player): GameResult {
+export function simulateGame(
+  playerA: Player,
+  playerB: Player,
+  server: Player,
+  logger?: Logger
+): GameResult {
   let scoreA = 0;
   let scoreB = 0;
   let serving = server;
+  logger?.log('game', `Game start. Server ${server.name}`);
   while (true) {
     const receiver = serving === playerA ? playerB : playerA;
-    const { winner } = simulateRally(serving, receiver);
+    const { winner } = simulateRally(serving, receiver, 5, 1, logger);
     if (winner === serving) {
       if (serving === playerA) scoreA++; else scoreB++;
     } else {
       if (receiver === playerA) scoreA++; else scoreB++;
       serving = receiver;
     }
+    logger?.log('game', `${scoreA}-${scoreB} serving ${serving.name}`);
     if ((scoreA >= 21 || scoreB >= 21) && Math.abs(scoreA - scoreB) >= 2) break;
     if (scoreA === 30 || scoreB === 30) break;
   }
-  return { winner: scoreA > scoreB ? playerA : playerB, scoreA, scoreB };
+  const winner = scoreA > scoreB ? playerA : playerB;
+  logger?.log('game', `Game winner ${winner.name}`);
+  return { winner, scoreA, scoreB };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,9 @@
 export { simulateMatch } from './match.js';
-export type { Player, GameResult, MatchResult } from './types.js';
+export type {
+  Player,
+  GameResult,
+  MatchResult,
+  Logger,
+  LogLevel
+} from './types.js';
+export { ConsoleLogger } from './types.js';

--- a/src/match.ts
+++ b/src/match.ts
@@ -1,16 +1,27 @@
-import { Player, MatchResult, GameResult } from './types.js';
+import { Player, MatchResult, GameResult, Logger } from './types.js';
 import { simulateGame } from './game.js';
 
-export function simulateMatch(playerA: Player, playerB: Player): MatchResult {
+export function simulateMatch(
+  playerA: Player,
+  playerB: Player,
+  logger?: Logger
+): MatchResult {
   let startingServer = playerA;
   const games: GameResult[] = [];
   let winsA = 0;
   let winsB = 0;
+  logger?.log('match', `Match start ${playerA.name} vs ${playerB.name}`);
   while (winsA < 2 && winsB < 2) {
-    const result = simulateGame(playerA, playerB, startingServer);
+    const result = simulateGame(playerA, playerB, startingServer, logger);
     games.push(result);
     if (result.winner === playerA) winsA++; else winsB++;
+    logger?.log(
+      'match',
+      `Game finished ${result.scoreA}-${result.scoreB} winner ${result.winner.name}`
+    );
     startingServer = startingServer === playerA ? playerB : playerA;
   }
-  return { winner: winsA > winsB ? playerA : playerB, games };
+  const winner = winsA > winsB ? playerA : playerB;
+  logger?.log('match', `Match winner ${winner.name}`);
+  return { winner, games };
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,10 +1,12 @@
 import { simulateMatch } from './match.js';
-import { Player } from './types.js';
+import { Player, ConsoleLogger, LogLevel } from './types.js';
 
 const player1: Player = { name: 'Alice', technique: 8, mind: 7, physique: 8, emotion: 6 };
 const player2: Player = { name: 'Bob', technique: 7, mind: 7, physique: 7, emotion: 7 };
 
-const result = simulateMatch(player1, player2);
+const logger = new ConsoleLogger(new Set<LogLevel>(['rallyDetailed', 'rally', 'game', 'match']));
+
+const result = simulateMatch(player1, player2, logger);
 console.log('Match result:');
 result.games.forEach((g, i) => {
   console.log(`Game ${i + 1}: ${g.scoreA}-${g.scoreB} winner: ${g.winner.name}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,3 +21,19 @@ export interface MatchResult {
   winner: Player;
   games: GameResult[];
 }
+
+export type LogLevel = 'rallyDetailed' | 'rally' | 'game' | 'match';
+
+export interface Logger {
+  log(level: LogLevel, message: string): void;
+}
+
+export class ConsoleLogger implements Logger {
+  constructor(private enabled: Set<LogLevel>) {}
+
+  log(level: LogLevel, message: string): void {
+    if (this.enabled.has(level)) {
+      console.log(`[${level}] ${message}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement a simple logger with log levels
- add optional logging to calculateResponse, simulateRally, simulateGame, and simulateMatch
- export logger types and console implementation
- update example test to use a console logger

## Testing
- `npm test`
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_68697bab1c70832b892571ee2b5d5236