### PR TITLE
Revise rally calculations and add serve stat

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -6,8 +6,9 @@ export function calculateResponse(
   risk = 1,
   logger?: Logger
 ): number {
-  const product = player.technique * player.mind * player.physique * player.emotion;
-  let quality = (product / 1000) * ((10 - incoming) / 10) * risk;
+  const mean =
+    (player.technique + player.mind + player.physique + player.emotion) / 4;
+  let quality = (mean + (5 - incoming)) * risk;
   if (quality > 10) quality = 10;
   if (quality < 0) quality = 0;
   logger?.log('rallyDetailed', `${player.name} responds ${quality.toFixed(2)} to ${incoming}`);
@@ -17,15 +18,14 @@ export function calculateResponse(
 export function simulateRally(
   server: Player,
   receiver: Player,
-  firstShot = 5,
   risk = 1,
   logger?: Logger
 ): RallyResult {
   let hitter = receiver;
   let defender = server;
-  let incoming = firstShot;
+  let incoming = server.serve;
   const log = [incoming];
-  logger?.log('rally', `Rally starts. Server ${server.name} first ${firstShot}`);
+  logger?.log('rally', `Rally starts. Server ${server.name} first ${incoming}`);
   while (true) {
     const response = calculateResponse(hitter, incoming, risk, logger);
     log.push(response);

--- a/src/game.ts
+++ b/src/game.ts
@@ -13,7 +13,7 @@ export function simulateGame(
   logger?.log('game', `Game start. Server ${server.name}`);
   while (true) {
     const receiver = serving === playerA ? playerB : playerA;
-    const { winner } = simulateRally(serving, receiver, 5, 1, logger);
+    const { winner } = simulateRally(serving, receiver, 1, logger);
     if (winner === serving) {
       if (serving === playerA) scoreA++; else scoreB++;
     } else {

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,8 +1,8 @@
 import { simulateMatch } from './match.js';
 import { Player, ConsoleLogger, LogLevel } from './types.js';
 
-const player1: Player = { name: 'Alice', technique: 8, mind: 7, physique: 8, emotion: 6 };
-const player2: Player = { name: 'Bob', technique: 7, mind: 7, physique: 7, emotion: 7 };
+const player1: Player = { name: 'Alice', technique: 8, mind: 7, physique: 8, emotion: 6, serve: 6 };
+const player2: Player = { name: 'Bob', technique: 7, mind: 7, physique: 7, emotion: 7, serve: 5 };
 
 const logger = new ConsoleLogger(new Set<LogLevel>(['rallyDetailed', 'rally', 'game', 'match']));
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export interface Player {
   mind: number;
   physique: number;
   emotion: number;
+  serve: number;
 }
 
 export interface RallyResult {


### PR DESCRIPTION
## Summary
- incorporate new player attribute `serve`
- compute responses based on average characteristics
- modify rally start to use server's serve value
- adjust game logic to new rally API
- update sample players for serve

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68697f533690832b93d40f22a86822d5