### PR TITLE
Implement fatigue and randomness in rally simulation

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -4,14 +4,21 @@ export function calculateResponse(
   player: Player,
   incoming: number,
   risk = 1,
+  rallyFatigue = 0,
   logger?: Logger
 ): number {
+  const globalFatigue = player.fatigue ?? 0;
+  const physique = Math.max(0, player.physique - globalFatigue - rallyFatigue);
   const mean =
-    (player.technique + player.mind + player.physique + player.emotion) / 4;
+    (player.technique + player.mind + physique + player.emotion) / 4;
   let quality = (mean + (5 - incoming)) * risk;
+  quality += Math.random() * 4 - 2;
   if (quality > 10) quality = 10;
   if (quality < 0) quality = 0;
-  logger?.log('rallyDetailed', `${player.name} responds ${quality.toFixed(2)} to ${incoming}`);
+  logger?.log(
+    'rallyDetailed',
+    `${player.name} responds ${quality.toFixed(2)} to ${incoming}`
+  );
   return quality;
 }
 
@@ -23,22 +30,35 @@ export function simulateRally(
 ): RallyResult {
   let hitter = receiver;
   let defender = server;
-  let incoming = server.serve;
+  const rallyFatigue = new Map<Player, number>([
+    [server, 0],
+    [receiver, 0],
+  ]);
+  let incoming = server.serve + Math.random() * 4 - 2;
+  rallyFatigue.set(server, 0.2);
   const log = [incoming];
   logger?.log('rally', `Rally starts. Server ${server.name} first ${incoming}`);
+  const finishRally = (winner: Player): RallyResult => {
+    for (const p of [server, receiver]) {
+      const f = rallyFatigue.get(p) ?? 0;
+      p.fatigue = (p.fatigue ?? 0) + f * 0.1;
+      rallyFatigue.set(p, 0);
+    }
+    logger?.log('rally', `Rally winner ${winner.name}`);
+    return { winner, log };
+  };
   while (true) {
-    const response = calculateResponse(hitter, incoming, risk, logger);
+    const hitterFatigue = rallyFatigue.get(hitter) ?? 0;
+    const response = calculateResponse(hitter, incoming, risk, hitterFatigue, logger);
     log.push(response);
-    logger?.log('rallyDetailed', `${hitter.name} -> ${response.toFixed(2)}`);
     if (response >= 9) {
-      logger?.log('rally', `Rally winner ${hitter.name}`);
-      return { winner: hitter, log };
+      return finishRally(hitter);
     }
     if (response <= 2) {
-      logger?.log('rally', `Rally winner ${defender.name}`);
-      return { winner: defender, log };
+      return finishRally(defender);
     }
     incoming = response;
+    rallyFatigue.set(hitter, hitterFatigue + 0.2);
     [hitter, defender] = [defender, hitter];
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface Player {
   physique: number;
   emotion: number;
   serve: number;
+  fatigue?: number;
 }
 
 export interface RallyResult {


### PR DESCRIPTION
## Summary
- add global `fatigue` property to `Player`
- introduce random variance and fatigue handling in `calculateResponse`
- apply fatigue updates and randomised serve in `simulateRally`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686985e99330832bbd6edf247aba1a56