### PR TITLE
Add localized log messages

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,5 +1,6 @@
 import { Player, RallyResult, Logger } from './types.js';
 import { adjustByAttribute } from './utils.js';
+import { logMessages } from './logMessages.js';
 
 export function calculateResponse(
   player: Player,
@@ -19,7 +20,12 @@ export function calculateResponse(
   if (quality < 0) quality = 0;
   logger?.log(
     'rallyDetailed',
-    `${player.name} responds ${quality.toFixed(2)} to ${incoming}`
+    logMessages.rallyResponse(
+      logger?.language ?? 'en',
+      player.name,
+      quality,
+      incoming,
+    ),
   );
   return quality;
 }
@@ -39,7 +45,14 @@ export function simulateRally(
   let incoming = server.serve + Math.random() * 4 - 2;
   rallyFatigue.set(server, 0.2);
   const log = [incoming];
-  logger?.log('rally', `Rally starts. Server ${server.name} first ${incoming}`);
+  logger?.log(
+    'rally',
+    logMessages.rallyStart(
+      logger?.language ?? 'en',
+      server.name,
+      incoming,
+    ),
+  );
   const finishRally = (winner: Player): RallyResult => {
     for (const p of [server, receiver]) {
       const f = rallyFatigue.get(p) ?? 0;
@@ -48,7 +61,10 @@ export function simulateRally(
       p.fatigue = (p.fatigue ?? 0) + fatigueGain;
       rallyFatigue.set(p, 0);
     }
-    logger?.log('rally', `Rally winner ${winner.name}`);
+    logger?.log(
+      'rally',
+      logMessages.rallyWinner(logger?.language ?? 'en', winner.name),
+    );
     return { winner, log };
   };
   while (true) {

--- a/src/game.ts
+++ b/src/game.ts
@@ -1,6 +1,7 @@
 import { Player, GameResult, Logger } from "./types.js";
 import { simulateRally } from "./engine.js";
 import { adjustByAttribute } from "./utils.js";
+import { logMessages } from "./logMessages.js";
 
 export function simulateGame(
   playerA: Player,
@@ -11,7 +12,10 @@ export function simulateGame(
   let scoreA = 0;
   let scoreB = 0;
   let serving = server;
-  logger?.log("game", `Game start. Server ${server.name}`);
+  logger?.log(
+    "game",
+    logMessages.gameStart(logger?.language ?? "en", server.name),
+  );
   while (true) {
     const scoreDiff = Math.abs(scoreA - scoreB);
     const scoreAny = Math.max(scoreA, scoreB);
@@ -21,7 +25,11 @@ export function simulateGame(
         const clutchPenalty = adjustByAttribute(2, p.emotion);
         logger?.log(
           "rallyDetailed",
-          `Clutch value for ${p.name} is ${clutchPenalty} `,
+          logMessages.clutchValue(
+            logger?.language ?? "en",
+            p.name,
+            clutchPenalty,
+          ),
         );
         p.emotionState = (p.emotionState ?? 0) - clutchPenalty;
       }
@@ -29,12 +37,15 @@ export function simulateGame(
 
     logger?.log(
       "rallyDetailed",
-      `Before rally: ${playerA.name} F:${(playerA.fatigue ?? 0).toFixed(
-        2,
-      )} E:${(playerA.emotionState ?? 0).toFixed(2)} | ` +
-        `${playerB.name} F:${(playerB.fatigue ?? 0).toFixed(2)} E:${(
-          playerB.emotionState ?? 0
-        ).toFixed(2)}`,
+      logMessages.beforeRally(
+        logger?.language ?? "en",
+        playerA.name,
+        playerA.fatigue ?? 0,
+        playerA.emotionState ?? 0,
+        playerB.name,
+        playerB.fatigue ?? 0,
+        playerB.emotionState ?? 0,
+      ),
     );
 
     const receiver = serving === playerA ? playerB : playerA;
@@ -51,11 +62,22 @@ export function simulateGame(
     const penalty = adjustByAttribute(0.5, loser.emotion);
     loser.emotionState = (loser.emotionState ?? 0) - penalty;
     winner.emotionState = 0;
-    logger?.log("game", `${scoreA}-${scoreB} serving ${serving.name}`);
+    logger?.log(
+      "game",
+      logMessages.score(
+        logger?.language ?? "en",
+        scoreA,
+        scoreB,
+        serving.name,
+      ),
+    );
     if ((scoreA >= 21 || scoreB >= 21) && Math.abs(scoreA - scoreB) >= 2) break;
     if (scoreA === 30 || scoreB === 30) break;
   }
   const winner = scoreA > scoreB ? playerA : playerB;
-  logger?.log("game", `Game winner ${winner.name}`);
+  logger?.log(
+    "game",
+    logMessages.gameWinner(logger?.language ?? "en", winner.name),
+  );
   return { winner, scoreA, scoreB };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,4 @@ export type {
   LogLevel
 } from './types.js';
 export { ConsoleLogger } from './types.js';
+export type { Language } from './logMessages.js';

--- a/src/logMessages.ts
+++ b/src/logMessages.ts
@@ -1,0 +1,66 @@
+export type Language = 'en' | 'ru';
+
+export const logMessages = {
+  rallyStart: (lang: Language, server: string, first: number) =>
+    lang === 'ru'
+      ? `Розыгрыш начинается. Подает ${server}, первый удар ${first}`
+      : `Rally starts. Server ${server} first ${first}`,
+  rallyWinner: (lang: Language, winner: string) =>
+    lang === 'ru'
+      ? `Очко выигрывает ${winner}`
+      : `Rally winner ${winner}`,
+  rallyResponse: (
+    lang: Language,
+    player: string,
+    quality: number,
+    incoming: number,
+  ) =>
+    lang === 'ru'
+      ? `${player} отвечает ${quality.toFixed(2)} на ${incoming}`
+      : `${player} responds ${quality.toFixed(2)} to ${incoming}`,
+  gameStart: (lang: Language, server: string) =>
+    lang === 'ru'
+      ? `Начало игры. Подает ${server}`
+      : `Game start. Server ${server}`,
+  clutchValue: (lang: Language, player: string, value: number) =>
+    lang === 'ru'
+      ? `Показатель клатча для ${player} равен ${value} `
+      : `Clutch value for ${player} is ${value} `,
+  beforeRally: (
+    lang: Language,
+    aName: string,
+    aFatigue: number,
+    aEmotion: number,
+    bName: string,
+    bFatigue: number,
+    bEmotion: number,
+  ) =>
+    lang === 'ru'
+      ? `Перед розыгрышем: ${aName} Уст:${aFatigue.toFixed(2)} Эм:${aEmotion.toFixed(
+          2,
+        )} | ${bName} Уст:${bFatigue.toFixed(2)} Эм:${bEmotion.toFixed(2)}`
+      : `Before rally: ${aName} F:${aFatigue.toFixed(2)} E:${aEmotion.toFixed(
+          2,
+        )} | ${bName} F:${bFatigue.toFixed(2)} E:${bEmotion.toFixed(2)}`,
+  score: (lang: Language, a: number, b: number, serving: string) =>
+    lang === 'ru'
+      ? `${a}-${b} подает ${serving}`
+      : `${a}-${b} serving ${serving}`,
+  gameWinner: (lang: Language, winner: string) =>
+    lang === 'ru' ? `Победа в игре ${winner}` : `Game winner ${winner}`,
+  matchStart: (lang: Language, a: string, b: string) =>
+    lang === 'ru'
+      ? `Матч начинается ${a} против ${b}`
+      : `Match start ${a} vs ${b}`,
+  gameFinished: (
+    lang: Language,
+    scoreA: number,
+    scoreB: number,
+    winner: string,
+  ) =>
+    lang === 'ru'
+      ? `Игра окончена ${scoreA}-${scoreB} победитель ${winner}`
+      : `Game finished ${scoreA}-${scoreB} winner ${winner}`,
+  matchWinner: (lang: Language, winner: string) =>
+    lang === 'ru' ? `Матч выиграл ${winner}` : `Match winner ${winner}`,
+} as const;

--- a/src/match.ts
+++ b/src/match.ts
@@ -1,5 +1,6 @@
 import { Player, MatchResult, GameResult, Logger } from './types.js';
 import { simulateGame } from './game.js';
+import { logMessages } from './logMessages.js';
 
 export function simulateMatch(
   playerA: Player,
@@ -10,18 +11,33 @@ export function simulateMatch(
   const games: GameResult[] = [];
   let winsA = 0;
   let winsB = 0;
-  logger?.log('match', `Match start ${playerA.name} vs ${playerB.name}`);
+  logger?.log(
+    'match',
+    logMessages.matchStart(
+      logger?.language ?? 'en',
+      playerA.name,
+      playerB.name,
+    ),
+  );
   while (winsA < 2 && winsB < 2) {
     const result = simulateGame(playerA, playerB, startingServer, logger);
     games.push(result);
     if (result.winner === playerA) winsA++; else winsB++;
     logger?.log(
       'match',
-      `Game finished ${result.scoreA}-${result.scoreB} winner ${result.winner.name}`
+      logMessages.gameFinished(
+        logger?.language ?? 'en',
+        result.scoreA,
+        result.scoreB,
+        result.winner.name,
+      ),
     );
     startingServer = startingServer === playerA ? playerB : playerA;
   }
   const winner = winsA > winsB ? playerA : playerB;
-  logger?.log('match', `Match winner ${winner.name}`);
+  logger?.log(
+    'match',
+    logMessages.matchWinner(logger?.language ?? 'en', winner.name),
+  );
   return { winner, games };
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -20,6 +20,7 @@ const player2: Player = {
 
 const logger = new ConsoleLogger(
   new Set<LogLevel>(["rallyDetailed", "rally", "game", "match"]),
+  "en",
 );
 
 const result = simulateMatch(player1, player2, logger);

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,12 +27,18 @@ export interface MatchResult {
 
 export type LogLevel = 'rallyDetailed' | 'rally' | 'game' | 'match';
 
+import type { Language } from './logMessages.js';
+
 export interface Logger {
+  language: Language;
   log(level: LogLevel, message: string): void;
 }
 
 export class ConsoleLogger implements Logger {
-  constructor(private enabled: Set<LogLevel>) {}
+  constructor(
+    private enabled: Set<LogLevel>,
+    public language: Language = 'en',
+  ) {}
 
   log(level: LogLevel, message: string): void {
     if (this.enabled.has(level)) {


### PR DESCRIPTION
## Summary
- centralize log strings in `logMessages.ts` and provide Russian translations
- extend `Logger` to include a `language` option and update `ConsoleLogger`
- integrate `logMessages` usage across engine, game and match logic
- export new `Language` type
- update test to use new logger interface

## Testing
- `npm install`
- `npm test`
- `npx tsc`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686a5caef6e4832b8adaa4964bb9e997