### PR TITLE
Implement score-aware matchWinner log and refactor logging

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -72,10 +72,9 @@ export function simulateRally(
       rallyFatigue.set(p, 0);
     }
     const [line1, line2] = formatRallyLog(server, receiver, log);
-    logger?.log("rallyDetailed", line1);
-    logger?.log("rallyDetailed", line2);
+    logger?.log({ level: "rallyDetailed", text: line1 });
+    logger?.log({ level: "rallyDetailed", text: line2 });
     logger?.log(
-      "rally",
       logMessages.rallyWinner(logger?.language ?? "en", winner.name),
     );
     return { winner, log };

--- a/src/game.ts
+++ b/src/game.ts
@@ -14,10 +14,7 @@ export function simulateGame(
   let serving = server;
   let streakA = 0;
   let streakB = 0;
-  logger?.log(
-    "game",
-    logMessages.gameStart(logger?.language ?? "en", server.name),
-  );
+  logger?.log(logMessages.gameStart(logger?.language ?? "en", server.name));
   while (true) {
     const scoreDiff = Math.abs(scoreA - scoreB);
     const isClose = scoreDiff <= 1;
@@ -30,7 +27,6 @@ export function simulateGame(
     for (const p of tensePlayers) {
       const clutchPenalty = adjustByAttribute(2, p.emotion);
       logger?.log(
-        "debug",
         logMessages.clutchValue(
           logger?.language ?? "en",
           p.name,
@@ -41,7 +37,6 @@ export function simulateGame(
     }
 
     logger?.log(
-      "debug",
       logMessages.beforeRally(
         logger?.language ?? "en",
         playerA.name,
@@ -82,16 +77,17 @@ export function simulateGame(
       playerA.emotionState = 0;
     }
     logger?.log(
-      "game",
-      logMessages.score(logger?.language ?? "en", scoreA, scoreB, serving.name),
+      logMessages.score(
+        logger?.language ?? "en",
+        scoreA,
+        scoreB,
+        serving.name,
+      ),
     );
     if ((scoreA >= 21 || scoreB >= 21) && Math.abs(scoreA - scoreB) >= 2) break;
     if (scoreA === 30 || scoreB === 30) break;
   }
   const winner = scoreA > scoreB ? playerA : playerB;
-  logger?.log(
-    "game",
-    logMessages.gameWinner(logger?.language ?? "en", winner.name),
-  );
+  logger?.log(logMessages.gameWinner(logger?.language ?? "en", winner.name));
   return { winner, scoreA, scoreB };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,8 @@ export type {
   GameResult,
   MatchResult,
   Logger,
-  LogLevel
+  LogLevel,
+  LogMessage
 } from './types.js';
 export { ConsoleLogger } from './types.js';
 export { HtmlLogger } from './types.js';

--- a/src/logMessages.ts
+++ b/src/logMessages.ts
@@ -1,29 +1,40 @@
 export type Language = "en" | "ru";
+import type { LogMessage, LogLevel } from './types.js';
+
+function msg(level: LogLevel, text: string): LogMessage {
+  return { level, text };
+}
 
 export const logMessages = {
-  rallyStart: (lang: Language, server: string, first: number) =>
-    lang === "ru"
-      ? `Розыгрыш начинается. Подает ${server}, первый удар ${first}`
-      : `Rally starts. Server ${server} first ${first}`,
-  rallyWinner: (lang: Language, winner: string) =>
-    lang === "ru" ? `Очко выигрывает ${winner}` : `Rally winner ${winner}`,
+  rallyStart: (lang: Language, server: string, first: number): LogMessage =>
+    msg(
+      'rally',
+      lang === 'ru'
+        ? `Розыгрыш начинается. Подает ${server}, первый удар ${first}`
+        : `Rally starts. Server ${server} first ${first}`,
+    ),
+  rallyWinner: (lang: Language, winner: string): LogMessage =>
+    msg('rally', lang === 'ru' ? `Очко выигрывает ${winner}` : `Rally winner ${winner}`),
   rallyResponse: (
     lang: Language,
     player: string,
     quality: number,
     incoming: number,
   ) =>
-    lang === "ru"
-      ? `${player} отвечает ${quality.toFixed(2)} на ${incoming}`
-      : `${player} responds ${quality.toFixed(2)} to ${incoming}`,
-  gameStart: (lang: Language, server: string) =>
-    lang === "ru"
-      ? `Начало гейма. Подает ${server}`
-      : `Game start. Server ${server}`,
-  clutchValue: (lang: Language, player: string, value: number) =>
-    lang === "ru"
-      ? `Показатель клатча для ${player} равен ${value} `
-      : `Clutch value for ${player} is ${value} `,
+    msg(
+      'debug',
+      lang === 'ru'
+        ? `${player} отвечает ${quality.toFixed(2)} на ${incoming}`
+        : `${player} responds ${quality.toFixed(2)} to ${incoming}`,
+    ),
+  gameStart: (lang: Language, server: string): LogMessage =>
+    msg('game', lang === 'ru' ? `Начало гейма. Подает ${server}` : `Game start. Server ${server}`),
+  clutchValue: (lang: Language, player: string, value: number): LogMessage =>
+    msg('debug',
+      lang === 'ru'
+        ? `Показатель клатча для ${player} равен ${value} `
+        : `Clutch value for ${player} is ${value} `,
+    ),
   beforeRally: (
     lang: Language,
     aName: string,
@@ -33,38 +44,43 @@ export const logMessages = {
     bFatigue: number,
     bEmotion: number,
   ) =>
-    lang === "ru"
-      ? `Перед розыгрышем: ${aName} Уст:${aFatigue.toFixed(
-          2,
-        )} Эм:${aEmotion.toFixed(2)} | ${bName} Уст:${bFatigue.toFixed(
-          2,
-        )} Эм:${bEmotion.toFixed(2)}`
-      : `Before rally: ${aName} F:${aFatigue.toFixed(2)} E:${aEmotion.toFixed(
-          2,
-        )} | ${bName} F:${bFatigue.toFixed(2)} E:${bEmotion.toFixed(2)}`,
-  score: (lang: Language, a: number, b: number, serving: string) =>
-    lang === "ru"
-      ? `${a}-${b} подает ${serving}`
-      : `${a}-${b} serving ${serving}`,
-  gameWinner: (lang: Language, winner: string) =>
-    lang === "ru" ? `Победа в гейме ${winner}` : `Game winner ${winner}`,
-  matchStart: (lang: Language, a: string, b: string) =>
-    lang === "ru" ? `🏸 Матч: ${a} против ${b}` : `🏸 Match: ${a} vs ${b}`,
+    msg(
+      'debug',
+      lang === 'ru'
+        ? `Перед розыгрышем: ${aName} Уст:${aFatigue.toFixed(2)} Эм:${aEmotion.toFixed(
+            2,
+          )} | ${bName} Уст:${bFatigue.toFixed(2)} Эм:${bEmotion.toFixed(2)}`
+        : `Before rally: ${aName} F:${aFatigue.toFixed(2)} E:${aEmotion.toFixed(
+            2,
+          )} | ${bName} F:${bFatigue.toFixed(2)} E:${bEmotion.toFixed(2)}`,
+    ),
+  score: (lang: Language, a: number, b: number, serving: string): LogMessage =>
+    msg('game', lang === 'ru' ? `${a}-${b} подает ${serving}` : `${a}-${b} serving ${serving}`),
+  gameWinner: (lang: Language, winner: string): LogMessage =>
+    msg('game', lang === 'ru' ? `Победа в гейме ${winner}` : `Game winner ${winner}`),
+  matchStart: (lang: Language, a: string, b: string): LogMessage =>
+    msg('match', lang === 'ru' ? `🏸 Матч: ${a} против ${b}` : `🏸 Match: ${a} vs ${b}`),
   gameFinished: (
     lang: Language,
     scoreA: number,
     scoreB: number,
     winner: string,
   ) =>
-    lang === "ru"
-      ? `Гейм завершен ${scoreA}-${scoreB} победитель ${winner}`
-      : `Game finished ${scoreA}-${scoreB} winner ${winner}`,
-  matchWinner: (lang: Language, winner: string) =>
-    lang === "ru"
-      ? `🏆 Победитель матча: ${winner}`
-      : `🏆 Match winner: ${winner}`,
+    msg(
+      'match',
+      lang === 'ru'
+        ? `Гейм завершен ${scoreA}-${scoreB} победитель ${winner}`
+        : `Game finished ${scoreA}-${scoreB} winner ${winner}`,
+    ),
+  matchWinner: (lang: Language, winner: string, scores: number[]): LogMessage =>
+    msg(
+      'match',
+      lang === 'ru'
+        ? `🏆 Победитель матча: ${winner} (${scores.join(', ')})`
+        : `🏆 Match winner: ${winner} (${scores.join(', ')})`,
+    ),
   matchResultHeader: (lang: Language) =>
-    lang === "ru" ? "Результат матча:" : "Match result:",
+    msg('match', lang === 'ru' ? 'Результат матча:' : 'Match result:'),
   matchResultGame: (
     lang: Language,
     game: number,
@@ -72,7 +88,10 @@ export const logMessages = {
     scoreB: number,
     winner: string,
   ) =>
-    lang === "ru"
-      ? `Гейм ${game}: ${scoreA}-${scoreB} победитель: ${winner}`
-      : `Game ${game}: ${scoreA}-${scoreB} winner: ${winner}`,
+    msg(
+      'match',
+      lang === 'ru'
+        ? `Гейм ${game}: ${scoreA}-${scoreB} победитель: ${winner}`
+        : `Game ${game}: ${scoreA}-${scoreB} winner: ${winner}`,
+    ),
 } as const;

--- a/src/match.ts
+++ b/src/match.ts
@@ -12,7 +12,6 @@ export function simulateMatch(
   let winsA = 0;
   let winsB = 0;
   logger?.log(
-    "match",
     logMessages.matchStart(
       logger?.language ?? "en",
       playerA.name,
@@ -39,7 +38,6 @@ export function simulateMatch(
   // logger?.log("match", logMessages.matchResultHeader(logger?.language ?? "en"));
   games.forEach((g, i) =>
     logger?.log(
-      "match",
       logMessages.matchResultGame(
         logger?.language ?? "en",
         i + 1,
@@ -49,9 +47,18 @@ export function simulateMatch(
       ),
     ),
   );
+  const losingScores = games.map((g) => {
+    if (g.winner === winner) {
+      return g.winner === playerA ? g.scoreB : g.scoreA;
+    }
+    return -(g.winner === playerA ? g.scoreA : g.scoreB);
+  });
   logger?.log(
-    "match",
-    logMessages.matchWinner(logger?.language ?? "en", winner.name),
+    logMessages.matchWinner(
+      logger?.language ?? "en",
+      winner.name,
+      losingScores,
+    ),
   );
   return { winner, games };
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -19,7 +19,7 @@ const player2: Player = {
 };
 
 const logger = new ConsoleLogger(
-  new Set<LogLevel>(["game", "rally"]),
+  new Set<LogLevel>(["game", "rally", "match"]),
   // "rallyDetailed", "rally", "game",
   "ru",
 );

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,9 +29,14 @@ export type LogLevel = "debug" | "rallyDetailed" | "rally" | "game" | "match";
 
 import type { Language } from "./logMessages.js";
 
+export interface LogMessage {
+  level: LogLevel;
+  text: string;
+}
+
 export interface Logger {
   language: Language;
-  log(level: LogLevel, message: string): void;
+  log(message: LogMessage): void;
 }
 
 export class ConsoleLogger implements Logger {
@@ -40,9 +45,9 @@ export class ConsoleLogger implements Logger {
     public language: Language = "en",
   ) {}
 
-  log(level: LogLevel, message: string): void {
-    if (this.enabled.has(level)) {
-      console.log(`[${level}] ${message}`);
+  log(message: LogMessage): void {
+    if (this.enabled.has(message.level)) {
+      console.log(`[${message.level}] ${message.text}`);
     }
   }
 }
@@ -54,9 +59,9 @@ export class HtmlLogger implements Logger {
     public language: Language = "en",
   ) {}
 
-  log(level: LogLevel, message: string): void {
-    if (this.enabled.has(level)) {
-      this.logs.push(`<p>[${level}] ${message}</p>`);
+  log(message: LogMessage): void {
+    if (this.enabled.has(message.level)) {
+      this.logs.push(`<p>[${message.level}] ${message.text}</p>`);
     }
   }
 


### PR DESCRIPTION
## Summary
- refactor logging API so messages carry their log level
- update log message builders to return levelled messages
- include badminton notation of losing scores in the `matchWinner` message
- adapt engine, game, and match code to new logging API
- update exports and sample test

## Testing
- `npm install`
- `npm test`
- `node --loader ts-node/esm src/test.ts`

------
https://chatgpt.com/codex/tasks/task_e_686a783f4430832b9009ee8d2b690ca1