### PR TITLE
Add README and typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# badminton-engine
+
+Simulation engine for badminton matches and tournaments written in TypeScript.
+
+## Installation
+
+```bash
+npm install badminton-engine
+```
+
+## Build from sources
+
+```bash
+npm install
+npm run build
+```
+
+Compiled files will be placed into the `dist` directory and bundled to `engine.js`.
+
+## Usage
+
+```ts
+import { simulateMatch, ConsoleLogger, Player } from 'badminton-engine';
+
+const playerA: Player = {
+  name: 'Alice',
+  technique: 8,
+  mind: 7,
+  physique: 8,
+  emotion: 5,
+  serve: 3,
+};
+
+const playerB: Player = {
+  name: 'Bob',
+  technique: 7,
+  mind: 7,
+  physique: 6,
+  emotion: 7,
+  serve: 6,
+};
+
+const logger = new ConsoleLogger(new Set(['match', 'game']), 'en');
+
+const result = simulateMatch(playerA, playerB, logger);
+console.log(result);
+```
+The logger accepts a language code (`'en'` or `'ru'`) and a set of log levels.
+The snippet above runs a single match simulation and prints the results to the console.
+
+## License
+
+[MIT](LICENSE)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "node",
     "outDir": "dist",
     "rootDir": "src",
+    "declaration": true,
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary
- add project README
- output TypeScript declaration files by enabling `declaration` in `tsconfig.json`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ab358e168832ba0b95b733e65c6f9