### PR TITLE
Add support for multiple loggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ Compiled files will be placed into the `dist` directory and bundled to `engine.j
 ## Usage
 
 ```ts
-import { simulateMatch, ConsoleLogger, Player } from 'badminton-engine';
+import {
+  simulateMatch,
+  ConsoleLogger,
+  HtmlLogger,
+  MultiLogger,
+  Player,
+} from 'badminton-engine';
 
 const playerA: Player = {
   name: 'Alice',
@@ -40,13 +46,16 @@ const playerB: Player = {
   serve: 6,
 };
 
-const logger = new ConsoleLogger(new Set(['match', 'game']), 'en');
+const consoleLogger = new ConsoleLogger(new Set(['match', 'game']), 'en');
+const htmlLogger = new HtmlLogger(new Set(['match', 'game']), 'en');
+const logger = new MultiLogger([consoleLogger, htmlLogger]);
 
 const result = simulateMatch(playerA, playerB, logger);
 console.log(result);
+// HTML logger content is available via htmlLogger.toHtml();
 ```
-The logger accepts a language code (`'en'` or `'ru'`) and a set of log levels.
-The snippet above runs a single match simulation and prints the results to the console.
+Each logger accepts a language code (`'en'` or `'ru'`) and a set of log levels.
+The snippet above runs a single match simulation, prints the results to the console and collects HTML output for further inspection.
 
 ## License
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,5 @@ export type {
 } from './types.js';
 export { ConsoleLogger } from './types.js';
 export { HtmlLogger } from './types.js';
+export { MultiLogger } from './types.js';
 export type { Language } from './logMessages.js';

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,5 +1,11 @@
 import { simulateMatch } from "./match.js";
-import { Player, ConsoleLogger, LogLevel } from "./types.js";
+import {
+  Player,
+  ConsoleLogger,
+  HtmlLogger,
+  MultiLogger,
+  LogLevel,
+} from "./types.js";
 
 const player1: Player = {
   name: "Alice",
@@ -18,9 +24,15 @@ const player2: Player = {
   serve: 6,
 };
 
-const logger = new ConsoleLogger(
-  new Set<LogLevel>([/*"game", "rally",*/ "game", "debug", "rallyDetailed", "rally", "match"]),
-  // "rallyDetailed", "rally", "game",
+const consoleLogger = new ConsoleLogger(
+  new Set<LogLevel>(["game", "debug", "rallyDetailed", "rally", "match"]),
   "ru",
 );
+const htmlLogger = new HtmlLogger(
+  new Set<LogLevel>(["game", "debug", "rallyDetailed", "rally", "match"]),
+  "ru",
+);
+const logger = new MultiLogger([consoleLogger, htmlLogger]);
+
 simulateMatch(player1, player2, logger);
+console.log(htmlLogger.toHtml());

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,3 +69,17 @@ export class HtmlLogger implements Logger {
     return this.logs.join("\n");
   }
 }
+
+export class MultiLogger implements Logger {
+  public language: Language;
+
+  constructor(private loggers: Logger[], language?: Language) {
+    this.language = language ?? this.loggers[0]?.language ?? "en";
+  }
+
+  log(message: LogMessage): void {
+    for (const logger of this.loggers) {
+      logger.log(message);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `MultiLogger` to allow attaching several loggers
- export new class via public API
- update usage docs and tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c19de9328832b9ab92d60f6d90088